### PR TITLE
Update requirements.txt to allow Starlette Upgrades

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests==2.21.0
-starlette==0.11.4
-typesystem==0.2.0
+requests>=2.21.0
+starlette>=0.11.4
+typesystem>=0.2.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ install_requires = [
 
 setuptools.setup(
     name="starlette-jsonrpc",
-    version="0.2.0",
+    version="0.2.1",
     author="Kamil Dębowski",
     author_email="poczta@kdebowski.pl",
     description="JSON-RPC implementation for Starlette framework",


### PR DESCRIPTION
Makes requirements open ended instead of pinned to one version and bumps
the minor version number to v0.2.1