### PR TITLE
Allow to send 'error' with cause in JSONRPCResponse.

### DIFF
--- a/starlette_jsonrpc/schemas.py
+++ b/starlette_jsonrpc/schemas.py
@@ -29,7 +29,8 @@ class JSONRPCResponse(typesystem.Schema):
             typesystem.Integer(allow_null=True),
         ]
     )
-    result = typesystem.Any()
+    error = typesystem.Any(allow_null=True)
+    result = typesystem.Any(allow_null=True)
 
 
 class JSONRPCNotificationResponse(typesystem.Schema):


### PR DESCRIPTION
Allow to send 'error' with cause in JSONRPCResponse.
For example: {"jsonrpc": "2.0", "error": {"code": 666, "message": "Post not found"}, "id": "1"}